### PR TITLE
[AIRFLOW-1527] Refactor celery config

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -292,6 +292,8 @@ flower_port = 5555
 # Default queue that tasks get assigned to and that worker listen on.
 default_queue = default
 
+# Module import path for celery configuration
+celery_config_module = airflow.config_templates.default_celery
 
 [dask]
 # This section only applies if you are using the DaskExecutor in

--- a/airflow/config_templates/default_celery.py
+++ b/airflow/config_templates/default_celery.py
@@ -1,0 +1,55 @@
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+"""
+from airflow import configuration
+import logging
+import ssl
+from airflow.exceptions import AirflowConfigException, AirflowException
+
+# Broker settings.
+CELERY_ACCEPT_CONTENT = ['json', 'pickle']
+CELERY_EVENT_SERIALIZER = 'json'
+CELERY_RESULT_SERIALIZER = 'pickle'
+CELERY_TASK_SERIALIZER = 'pickle'
+CELERYD_PREFETCH_MULTIPLIER = 1
+CELERY_ACKS_LATE = True
+BROKER_URL = configuration.get('celery', 'BROKER_URL')
+CELERY_RESULT_BACKEND = configuration.get('celery', 'CELERY_RESULT_BACKEND')
+# Warning! CELERYD_CONCURRENCY should be modified in airflow.cfg only (if you run workers via airflow worker)
+CELERYD_CONCURRENCY = configuration.getint('celery', 'CELERYD_CONCURRENCY')
+CELERY_DEFAULT_QUEUE = configuration.get('celery', 'DEFAULT_QUEUE')
+CELERY_DEFAULT_EXCHANGE = configuration.get('celery', 'DEFAULT_QUEUE')
+
+celery_ssl_active = False
+try:
+    celery_ssl_active = configuration.getboolean('celery', 'CELERY_SSL_ACTIVE')
+except AirflowConfigException as e:
+    logging.warning("Celery Executor will run without SSL")
+
+try:
+    if celery_ssl_active:
+        BROKER_USE_SSL = {'keyfile': configuration.get('celery', 'CELERY_SSL_KEY'),
+                            'certfile': configuration.get('celery', 'CELERY_SSL_CERT'),
+                            'ca_certs': configuration.get('celery', 'CELERY_SSL_CACERT'),
+                            'cert_reqs': ssl.CERT_REQUIRED}
+except AirflowConfigException as e:
+    raise AirflowException('AirflowConfigException: CELERY_SSL_ACTIVE is True, please ensure CELERY_SSL_KEY, '
+                            'CELERY_SSL_CERT and CELERY_SSL_CACERT are set')
+except Exception as e:
+    raise AirflowException('Exception: There was an unknown Celery SSL Error.  Please ensure you want to use '
+                            'SSL and/or have all necessary certs and key.')


### PR DESCRIPTION
New config parameter "celery_config_module" to point to celery config
module

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

